### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Lightning fast 2D Perlin Noise generator"
 keywords = ["rand", "perlin"]
 categories = ["algorithms", "mathematics"]
 readme = "./README.md"
-repository = "https://www.github.com/gp-97/perlin"
+repository = "https://github.com/gp-97/perlin"
 
 
 [dependencies]


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96